### PR TITLE
v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,19 @@
 ### 0.4.0
 
 * Only `NewResponse()` method is required on the response when is added a new method
+
+### 0.5.0
+
+* `Code` in `ResponseMessage` for error responses
+* Helpers for responses. **Status**:
+    * OK
+    * Created
+    * Accepted
+    * NoContent
+    * BadRequest
+    * Unauthorized
+    * Forbidden
+    * NotFound
+    * MethodNotAllowed
+    * NotAcceptable
+    * InternalServerError

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ err := server.NewRoute(nil, "/create").AddMethod("POST", func(request httping.Ht
 	})
 ```
 
-### Response helpers
+### Responding
 
-This lib also brings some helpers for the response for the `handleFunc()`
+Responses for the `handleFunc()`
 
 For creating a `ResponseMessage`
 
@@ -100,7 +100,20 @@ err := server.NewRoute(nil, "/create").AddMethod("POST", func(request httping.Ht
 
 It respects the [jsend](https://github.com/omniti-labs/jsend)'s pattern. 
 
-On **responses** it also possible to add Headers and Message
+On **responses** it also possible to add Headers, Code and Message.
+
+There are a few helpers for the most commons http status codes.
+
+**Example**
+
+```go
+err := server.NewRoute(nil, "/create").AddMethod("POST", func(request httping.HttpRequest) (int, *httping.ResponseMessage) {
+		return httping.OK("data example")
+	})
+```
+
+It will return a status code ok (200) with the data `data example`
+You can check all the helpers [here](CHANGELOG.md#050).
 
 # Developer
 

--- a/response_helpers.go
+++ b/response_helpers.go
@@ -1,0 +1,47 @@
+package httping
+
+import "net/http"
+
+func OK(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusOK).AddData(data)
+}
+
+func Created(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusCreated).AddData(data)
+}
+
+func Accepted(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusAccepted).AddData(data)
+}
+
+func NoContent() *ResponseMessage {
+	return NewResponse(http.StatusNoContent)
+}
+
+func BadRequest(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusBadRequest).AddData(data)
+}
+
+func Unauthorized(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusUnauthorized).AddData(data)
+}
+
+func Forbidden(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusForbidden).AddData(data)
+}
+
+func NotFound(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusNotFound).AddData(data)
+}
+
+func MethodNotAllowed(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusMethodNotAllowed).AddData(data)
+}
+
+func NotAcceptable(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusNotAcceptable).AddData(data)
+}
+
+func InternalServerError(message string) *ResponseMessage {
+	return NewResponse(http.StatusInternalServerError).AddMessage(message)
+}

--- a/response_helpers_test.go
+++ b/response_helpers_test.go
@@ -1,0 +1,105 @@
+package httping
+
+import (
+	. "github.com/onsi/gomega"
+	"net/http"
+	"testing"
+)
+
+func TestOK(t *testing.T) {
+	RegisterTestingT(t)
+	resp := OK("test")
+	checkResponseSuccess(resp, http.StatusOK)
+}
+
+func TestCreated(t *testing.T) {
+	RegisterTestingT(t)
+	resp := Created("test")
+	checkResponseSuccess(resp, http.StatusCreated)
+}
+
+func TestAccepted(t *testing.T) {
+	RegisterTestingT(t)
+	resp := Accepted("test")
+	checkResponseSuccess(resp, http.StatusAccepted)
+}
+
+func TestNoContent(t *testing.T) {
+	RegisterTestingT(t)
+	resp := NoContent()
+	Expect(resp).ToNot(BeNil())
+	Expect(resp.Status).To(BeEquivalentTo(StatusSuccess))
+	Expect(resp.Code).To(BeEquivalentTo(""))
+	Expect(resp.Data).To(BeNil())
+	Expect(resp.Message).To(BeEquivalentTo(""))
+	Expect(resp.statusCode).To(BeEquivalentTo(http.StatusNoContent))
+	Expect(len(resp.headers)).To(BeEquivalentTo(0))
+}
+
+func TestBadRequest(t *testing.T) {
+	RegisterTestingT(t)
+	resp := BadRequest("test")
+	checkResponseFail(resp, http.StatusBadRequest)
+}
+
+func TestUnauthorized(t *testing.T) {
+	RegisterTestingT(t)
+	resp := Unauthorized("test")
+	checkResponseFail(resp, http.StatusUnauthorized)
+}
+
+func TestForbidden(t *testing.T) {
+	RegisterTestingT(t)
+	resp := Forbidden("test")
+	checkResponseFail(resp, http.StatusForbidden)
+}
+
+func TestNotFound(t *testing.T) {
+	RegisterTestingT(t)
+	resp := NotFound("test")
+	checkResponseFail(resp, http.StatusNotFound)
+}
+
+func TestMethodNotAllowed(t *testing.T) {
+	RegisterTestingT(t)
+	resp := MethodNotAllowed("test")
+	checkResponseFail(resp, http.StatusMethodNotAllowed)
+}
+
+func TestNotAcceptable(t *testing.T) {
+	RegisterTestingT(t)
+	resp := NotAcceptable("test")
+	checkResponseFail(resp, http.StatusNotAcceptable)
+}
+
+func TestInternalServerError(t *testing.T) {
+	RegisterTestingT(t)
+	resp := InternalServerError("test error message")
+	Expect(resp).ToNot(BeNil())
+	Expect(resp.Status).To(BeEquivalentTo(StatusError))
+	Expect(resp.Code).To(BeEquivalentTo(""))
+	Expect(resp.Data).To(BeNil())
+	Expect(resp.Message).To(BeEquivalentTo("test error message"))
+	Expect(resp.statusCode).To(BeEquivalentTo(http.StatusInternalServerError))
+	Expect(len(resp.headers)).To(BeEquivalentTo(0))
+}
+
+func checkResponseSuccess(resp *ResponseMessage, status int) {
+	Expect(resp).ToNot(BeNil())
+	Expect(resp.Status).To(BeEquivalentTo(StatusSuccess))
+	Expect(resp.Code).To(BeEquivalentTo(""))
+	Expect(resp.Data).To(BeEquivalentTo("test"))
+	Expect(resp.Message).To(BeEquivalentTo(""))
+	Expect(resp.statusCode).To(BeEquivalentTo(status))
+	Expect(len(resp.headers)).To(BeEquivalentTo(0))
+}
+
+func checkResponseFail(resp *ResponseMessage, status int) {
+	Expect(resp).ToNot(BeNil())
+	Expect(resp.Status).To(BeEquivalentTo(StatusFail))
+	Expect(resp.Code).To(BeEquivalentTo(""))
+	Expect(resp.Data).To(BeEquivalentTo("test"))
+	Expect(resp.Message).To(BeEquivalentTo(""))
+	Expect(resp.statusCode).To(BeEquivalentTo(status))
+	Expect(len(resp.headers)).To(BeEquivalentTo(0))
+}

--- a/response_message.go
+++ b/response_message.go
@@ -4,6 +4,7 @@ type ResponseMessage struct {
 	Status     ResponseStatus `json:"status"`
 	Data       interface{}    `json:"data,omitempty"`
 	Message    string         `json:"message,omitempty"`
+	Code       string         `json:"code,omitempty"`
 	headers    map[string][]string
 	statusCode int
 }
@@ -34,6 +35,11 @@ func (r *ResponseMessage) AddData(data interface{}) *ResponseMessage {
 
 func (r *ResponseMessage) AddMessage(message string) *ResponseMessage {
 	r.Message = message
+	return r
+}
+
+func (r *ResponseMessage) AddCode(code string) *ResponseMessage {
+	r.Code = code
 	return r
 }
 

--- a/response_message_test.go
+++ b/response_message_test.go
@@ -1,0 +1,80 @@
+package httping
+
+import (
+	. "github.com/onsi/gomega"
+	"net/http"
+	"testing"
+)
+
+func TestNewResponse(t *testing.T) {
+	RegisterTestingT(t)
+	resp := NewResponse(http.StatusOK)
+	Expect(resp).ToNot(BeNil())
+	Expect(resp.Status).To(BeEquivalentTo(StatusSuccess))
+	Expect(resp.Code).To(BeEquivalentTo(""))
+	Expect(resp.Data).To(BeNil())
+	Expect(resp.Message).To(BeEquivalentTo(""))
+	Expect(resp.statusCode).To(BeEquivalentTo(http.StatusOK))
+	Expect(len(resp.headers)).To(BeEquivalentTo(0))
+}
+
+func TestAddMessage(t *testing.T) {
+	RegisterTestingT(t)
+	resp := NewResponse(http.StatusInternalServerError).AddMessage("message error")
+	Expect(resp).ToNot(BeNil())
+	Expect(resp.Status).To(BeEquivalentTo(StatusError))
+	Expect(resp.Code).To(BeEquivalentTo(""))
+	Expect(resp.Data).To(BeNil())
+	Expect(resp.Message).To(BeEquivalentTo("message error"))
+	Expect(resp.statusCode).To(BeEquivalentTo(http.StatusInternalServerError))
+	Expect(len(resp.headers)).To(BeEquivalentTo(0))
+}
+
+func TestAddCode(t *testing.T) {
+	RegisterTestingT(t)
+	resp := NewResponse(http.StatusInternalServerError).AddCode("CODE-ERROR")
+	Expect(resp).ToNot(BeNil())
+	Expect(resp.Status).To(BeEquivalentTo(StatusError))
+	Expect(resp.Code).To(BeEquivalentTo("CODE-ERROR"))
+	Expect(resp.Data).To(BeNil())
+	Expect(resp.Message).To(BeEquivalentTo(""))
+	Expect(resp.statusCode).To(BeEquivalentTo(http.StatusInternalServerError))
+	Expect(len(resp.headers)).To(BeEquivalentTo(0))
+}
+
+func TestFailMessage(t *testing.T) {
+	RegisterTestingT(t)
+	resp := NewResponse(http.StatusBadRequest)
+	Expect(resp).ToNot(BeNil())
+	Expect(resp.Status).To(BeEquivalentTo(StatusFail))
+	Expect(resp.Code).To(BeEquivalentTo(""))
+	Expect(resp.Data).To(BeNil())
+	Expect(resp.Message).To(BeEquivalentTo(""))
+	Expect(resp.statusCode).To(BeEquivalentTo(http.StatusBadRequest))
+	Expect(len(resp.headers)).To(BeEquivalentTo(0))
+}
+
+func TestAddData(t *testing.T) {
+	RegisterTestingT(t)
+	resp := NewResponse(http.StatusOK).AddData("test")
+	Expect(resp).ToNot(BeNil())
+	Expect(resp.Status).To(BeEquivalentTo(StatusSuccess))
+	Expect(resp.Data).To(BeEquivalentTo("test"))
+	Expect(resp.Code).To(BeEquivalentTo(""))
+	Expect(resp.Message).To(BeEquivalentTo(""))
+	Expect(resp.statusCode).To(BeEquivalentTo(http.StatusOK))
+	Expect(len(resp.headers)).To(BeEquivalentTo(0))
+}
+
+func TestAddHeader(t *testing.T) {
+	RegisterTestingT(t)
+	resp := NewResponse(http.StatusOK).AddHeader("test key", "test value")
+	Expect(resp).ToNot(BeNil())
+	Expect(resp.Status).To(BeEquivalentTo(StatusSuccess))
+	Expect(resp.Code).To(BeEquivalentTo(""))
+	Expect(resp.Data).To(BeNil())
+	Expect(resp.Message).To(BeEquivalentTo(""))
+	Expect(resp.statusCode).To(BeEquivalentTo(http.StatusOK))
+	Expect(len(resp.headers)).To(BeEquivalentTo(1))
+	Expect(resp.headers["test key"][0]).To(BeEquivalentTo("test value"))
+}

--- a/version.go
+++ b/version.go
@@ -4,6 +4,6 @@ const ApplicationName = "httping-go"
 
 var GitCommit string
 
-const Version = "0.4.0"
+const Version = "0.5.0"
 
 var VersionPrerelease = ""


### PR DESCRIPTION
* `Code` in `ResponseMessage` for error responses
* Helpers for responses. **Status**:
    * OK
    * Created
    * Accepted
    * NoContent
    * BadRequest
    * Unauthorized
    * Forbidden
    * NotFound
    * MethodNotAllowed
    * NotAcceptable
    * InternalServerError