### PR TITLE
v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,3 +69,8 @@
 ### 0.7.2
 
 * Cookies is manageable on the **request** and **response** now on.
+
+## 0.8.0
+
+* Get for `status`, `headers` and `cookies` on `ResponseMessage`.
+* Fixing response no content(_status 204_) to respond no body

--- a/http_server_test.go
+++ b/http_server_test.go
@@ -361,6 +361,23 @@ func TestRequestAndResponseWithCookies(t *testing.T) {
 	Eventually(chErr).ShouldNot(Receive())
 }
 
+func TestNoContentResponse(t *testing.T) {
+	RegisterTestingT(t)
+	server := NewHttpServer(port)
+	server.NewRoute(nil, defaultPath).POST(func(request HttpRequest) *ResponseMessage {
+		return NoContent()
+	})
+	closeServer, chErr := server.RunServer()
+	defer closingServer(closeServer)
+	resp, err := http.Post(baseUrl+defaultPath, "application/json", bytes.NewReader([]byte("success")))
+	Expect(err).ShouldNot(HaveOccurred())
+	Expect(resp.StatusCode).Should(BeEquivalentTo(http.StatusNoContent))
+	body, err := ioutil.ReadAll(resp.Body)
+	Expect(err).ShouldNot(HaveOccurred())
+	Expect(len(body)).Should(BeEquivalentTo(0))
+	Expect(chErr).ToNot(Receive())
+}
+
 func closingServer(closeServerFn ServerCloseFunc) {
 	err := closeServerFn()
 	Expect(err).ShouldNot(HaveOccurred())

--- a/response_helpers_test.go
+++ b/response_helpers_test.go
@@ -28,7 +28,7 @@ func TestNoContent(t *testing.T) {
 	RegisterTestingT(t)
 	resp := NoContent()
 	Expect(resp).ToNot(BeNil())
-	Expect(resp.Status).To(BeEquivalentTo(StatusSuccess))
+	Expect(resp.Status).To(BeEquivalentTo(""))
 	Expect(resp.Code).To(BeEquivalentTo(""))
 	Expect(resp.Data).To(BeNil())
 	Expect(resp.Message).To(BeEquivalentTo(""))

--- a/response_message.go
+++ b/response_message.go
@@ -3,7 +3,7 @@ package httping
 import "net/http"
 
 type ResponseMessage struct {
-	Status     ResponseStatus `json:"status"`
+	Status     ResponseStatus `json:"status,omitempty"`
 	Data       interface{}    `json:"data,omitempty"`
 	Message    string         `json:"message,omitempty"`
 	Code       string         `json:"code,omitempty"`
@@ -22,10 +22,12 @@ const (
 
 func NewResponse(statusCode int) *ResponseMessage {
 	switch {
-	case statusCode >= 500:
+	case statusCode >= http.StatusInternalServerError:
 		return &ResponseMessage{Status: StatusError, headers: make(map[string][]string), statusCode: statusCode}
-	case statusCode >= 400 && statusCode < 500:
+	case statusCode >= http.StatusBadRequest && statusCode < http.StatusInternalServerError:
 		return &ResponseMessage{Status: StatusFail, headers: make(map[string][]string), statusCode: statusCode}
+	case statusCode == http.StatusNoContent:
+		return &ResponseMessage{statusCode: statusCode}
 	default:
 		return &ResponseMessage{Status: StatusSuccess, headers: make(map[string][]string), statusCode: statusCode}
 	}
@@ -65,4 +67,16 @@ func (r *ResponseMessage) AddCookie(cookie *http.Cookie) *ResponseMessage {
 func (r *ResponseMessage) SetCookies(cookies []*http.Cookie) *ResponseMessage {
 	r.cookies = cookies
 	return r
+}
+
+func (r *ResponseMessage) GetStatus() int {
+	return r.statusCode
+}
+
+func (r *ResponseMessage) GetCookies() []*http.Cookie {
+	return r.cookies
+}
+
+func (r *ResponseMessage) GetHeaders() map[string][]string {
+	return r.headers
 }

--- a/response_message_test.go
+++ b/response_message_test.go
@@ -4,6 +4,7 @@ import (
 	. "github.com/onsi/gomega"
 	"net/http"
 	"testing"
+	"time"
 )
 
 func TestNewResponse(t *testing.T) {
@@ -15,6 +16,7 @@ func TestNewResponse(t *testing.T) {
 	Expect(resp.Data).To(BeNil())
 	Expect(resp.Message).To(BeEquivalentTo(""))
 	Expect(resp.statusCode).To(BeEquivalentTo(http.StatusOK))
+	Expect(resp.GetStatus()).To(BeEquivalentTo(http.StatusOK))
 	Expect(len(resp.headers)).To(BeEquivalentTo(0))
 	resp.AddMessage("test message")
 	Expect(resp.Message).To(BeEquivalentTo(""))
@@ -43,6 +45,7 @@ func TestAddCode(t *testing.T) {
 	Expect(resp.Data).To(BeNil())
 	Expect(resp.Message).To(BeEquivalentTo(""))
 	Expect(resp.statusCode).To(BeEquivalentTo(http.StatusInternalServerError))
+	Expect(resp.GetStatus()).To(BeEquivalentTo(http.StatusInternalServerError))
 	Expect(len(resp.headers)).To(BeEquivalentTo(0))
 }
 
@@ -85,4 +88,55 @@ func TestAddHeader(t *testing.T) {
 	Expect(resp.statusCode).To(BeEquivalentTo(http.StatusOK))
 	Expect(len(resp.headers)).To(BeEquivalentTo(1))
 	Expect(resp.headers["test key"][0]).To(BeEquivalentTo("test value"))
+	headers := resp.GetHeaders()
+	Expect(len(headers)).To(BeEquivalentTo(1))
+	Expect(headers["test key"][0]).To(BeEquivalentTo("test value"))
+}
+
+func TestAddCookie(t *testing.T) {
+	RegisterTestingT(t)
+	cookie := &http.Cookie{
+		Name:    "cookie",
+		Value:   "value",
+		Path:    "/path",
+		Domain:  "domain",
+		Expires: time.Now().UTC().Add(time.Minute),
+		MaxAge:  600,
+	}
+	resp := OK(nil).AddCookie(cookie)
+	Expect(resp).ToNot(BeNil())
+	Expect(resp.Status).To(BeEquivalentTo(StatusSuccess))
+	Expect(resp.Code).To(BeEquivalentTo(""))
+	Expect(resp.Data).To(BeNil())
+	Expect(resp.Message).To(BeEquivalentTo(""))
+	Expect(resp.GetStatus()).To(BeEquivalentTo(http.StatusOK))
+	Expect(len(resp.GetHeaders())).To(BeEquivalentTo(0))
+	Expect(len(resp.GetCookies())).To(BeEquivalentTo(1))
+	Expect(resp.GetCookies()[0]).To(BeEquivalentTo(cookie))
+}
+
+func TestSetCookies(t *testing.T) {
+	RegisterTestingT(t)
+	var cookies []*http.Cookie
+	cookie := &http.Cookie{
+		Name:    "cookie",
+		Value:   "value",
+		Path:    "/path",
+		Domain:  "domain",
+		Expires: time.Now().UTC().Add(time.Minute),
+		MaxAge:  600,
+	}
+	cookies = append(cookies, cookie)
+	cookies = append(cookies, cookie)
+	resp := OK(nil).SetCookies(cookies)
+	Expect(resp).ToNot(BeNil())
+	Expect(resp.Status).To(BeEquivalentTo(StatusSuccess))
+	Expect(resp.Code).To(BeEquivalentTo(""))
+	Expect(resp.Data).To(BeNil())
+	Expect(resp.Message).To(BeEquivalentTo(""))
+	Expect(resp.GetStatus()).To(BeEquivalentTo(http.StatusOK))
+	Expect(len(resp.GetHeaders())).To(BeEquivalentTo(0))
+	Expect(len(resp.GetCookies())).To(BeEquivalentTo(2))
+	Expect(resp.GetCookies()[0]).To(BeEquivalentTo(cookie))
+	Expect(resp.GetCookies()[1]).To(BeEquivalentTo(cookie))
 }

--- a/version.go
+++ b/version.go
@@ -4,6 +4,6 @@ const ApplicationName = "httping-go"
 
 var GitCommit string
 
-const Version = "0.7.1"
+const Version = "0.8.0"
 
 var VersionPrerelease = ""


### PR DESCRIPTION
* Get for `status`, `headers` and `cookies` on `ResponseMessage`.
* Fixing response no content(_status 204_) to respond no body