### PR TITLE
v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,3 +113,35 @@ return anything that implements `IResponse` interface, which means anything besi
 ## 0.14.0
 
 * `EnableCORS()` now on is a method on the `IServer`. To enable CORS it is only needed to call the method.
+
+### 0.14.1
+
+* Helpers for responses. **Status**: 
+    * ProxyAuthRequired
+    * RequestTimeout
+    * Conflict
+    * Gone
+    * LengthRequired
+    * PreconditionFailed
+    * RequestEntityTooLarge
+    * RequestURITooLong
+    * UnsupportedMediaType
+    * RequestedRangeNotSatisfiable
+    * ExpectationFailed
+    * Teapot
+    * MisdirectedRequest
+    * UnprocessableEntity
+    * Locked
+    * FailedDependency
+    * TooEarly
+    * UpgradeRequired
+    * PreconditionRequired
+    * TooManyRequests
+    * RequestHeaderFieldsTooLarge
+    * UnavailableForLegalReasons
+    * NonAuthoritativeInfo
+    * ResetContent
+    * PartialContent
+    * MultiStatus
+    * AlreadyReported
+    * IMUsed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A helper to create APIs on golang with [JSend responses](https://github.com/omni
 
 * **[CHANGELOG](CHANGELOG.md)**
 
-Checkout some [example](http_server_test.go).
+Checkout some [example](examples).
 
 ## Getting started
 

--- a/examples/custom_responses/main.go
+++ b/examples/custom_responses/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+	"github.com/ednailson/httping-go"
+	"net/http"
+)
+
+//The httping package has a helper for responses. But you can build your own response builder
+
+func main() {
+
+	//Creating a server localhost port 8080
+	server := httping.NewHttpServer("", 8080)
+
+	//Setting up a route with a custom response
+	server.NewRoute(nil, "/example").POST(func(request httping.HttpRequest) httping.IResponse {
+		return &response{
+			data:       "OK!",
+			statusCode: http.StatusOK,
+		}
+	})
+
+	//Running the server
+	//If you close the server, you just need to call the closeServerFunc()
+	//chErr will receive any error that happened on the server
+	//We will have 1 routes on this server:
+	//POST /example
+	closeServeFunc, chErr := server.RunServer()
+
+	<-chErr
+	err := closeServeFunc()
+	if err != nil {
+		fmt.Sprintln(err.Error())
+	}
+}
+
+//To create a custom response it is only needed to implement the interface IResponse
+type response struct {
+	data       string
+	statusCode int
+}
+
+func (r *response) Headers() map[string][]string {
+	return nil
+}
+
+func (r *response) Cookies() []*http.Cookie {
+	return nil
+}
+
+func (r *response) Response() interface{} {
+	return r.data
+}
+
+func (r *response) StatusCode() int {
+	return r.statusCode
+}

--- a/examples/routes_and_middleware/main.go
+++ b/examples/routes_and_middleware/main.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"github.com/ednailson/httping-go"
+)
+
+func main() {
+
+	//Creating a server localhost port 8080
+	server := httping.NewHttpServer("", 8080)
+
+	//If your server will be accessed by browsers we recommend you to enable cors
+	server.EnableCORS()
+
+	//Adding a middleware func to the server. It means the every request to the server will pass by the middleware
+	//It is possible to remove the middleware to a specific route. The example is down below.
+	server.AddMiddleware(func(request httping.HttpRequest) httping.IResponse {
+		if request.Body == nil {
+
+			//This lib has some helpers to create response with JSend pattern.
+			//Here we are returning a BadRequest with a json data.
+			return httping.BadRequest(`{"body": "body is required"}`)
+		}
+
+		//If the middleware handle function return nil
+		//It means the the request will continue to the next handle functions
+		return nil
+	})
+
+	//Setting up a route
+	v1Route := server.NewRoute(nil, "/v1")
+
+	//Setting up a new route with a route base
+	//The route will be localhost:8080/v1/example
+	exampleRoute := server.NewRoute(v1Route, "/example")
+
+	//Adding a method POST to the exampleRoute with the handleFunc()
+	exampleRoute.POST(handleFunc())
+
+	//Adding a method GET to the same exampleRoute with the handleFunc2()
+	exampleRoute.GET(handleFunc2())
+
+	//Creating a new route with a route base without the server middleware handle function
+	//Adding already a POST method to the route with the handleFunc2()
+	server.NewRoute(v1Route, "/noMiddleware").SetMiddleware(nil).POST(handleFunc2())
+
+	//Running the server
+	//If you close the server, you just need to call the closeServerFunc()
+	//chErr will receive any error that happened on the server
+	//We will have 3 routes on this server:
+	//POST /v1/example
+	//GET /v1/example
+	//POST /v1/noMiddleware
+	closeServeFunc, chErr := server.RunServer()
+
+	<-chErr
+	err := closeServeFunc()
+	if err != nil {
+		fmt.Sprintln(err.Error())
+	}
+}
+
+func handleFunc() httping.HandlerFunc {
+	return func(request httping.HttpRequest) httping.IResponse {
+		if request.Params["authorization"] == "" {
+			return httping.Unauthorized(map[string]string{
+				"authorization": "unauthorized",
+			})
+		}
+
+		//Anything with the request can be made
+
+		return httping.NoContent()
+	}
+}
+
+func handleFunc2() httping.HandlerFunc {
+	return func(request httping.HttpRequest) httping.IResponse {
+
+		//Anything with the request can be made
+
+		return httping.OK("OK!")
+	}
+}

--- a/http_server_test.go
+++ b/http_server_test.go
@@ -401,7 +401,7 @@ func TestRouteWithMiddleware(t *testing.T) {
 
 func TestHttpServerWithCors(t *testing.T) {
 	RegisterTestingT(t)
-	server := NewHttpServer("", port, true)
+	server := NewHttpServer("", port).EnableCORS()
 	server.NewRoute(nil, "/").POST(func(request HttpRequest) IResponse {
 		return InternalServerError("internal server error")
 	})
@@ -421,7 +421,7 @@ func TestHttpServerWithCors(t *testing.T) {
 func TestManyMiddleware(t *testing.T) {
 	RegisterTestingT(t)
 	middlewareFuncServer := handleFuncCheckHeaderOrNil("Server", "middleware server", http.StatusInternalServerError)
-	server := NewHttpServer("", port, true).AddMiddleware(middlewareFuncServer)
+	server := NewHttpServer("", port).EnableCORS().AddMiddleware(middlewareFuncServer)
 	middlewareFuncRoute := handleFuncCheckHeaderOrNil("Route", "middleware route", http.StatusUnauthorized)
 	middlewareRoute := server.NewRoute(nil, "/middleware").AddMiddleware(middlewareFuncRoute)
 	middlewareRoute.POST(func(request HttpRequest) IResponse {

--- a/response_helpers.go
+++ b/response_helpers.go
@@ -18,6 +18,25 @@ func NoContent() *ResponseMessage {
 	return NewResponse(http.StatusNoContent)
 }
 
+func NonAuthoritativeInfo(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusNonAuthoritativeInfo).AddData(data)
+}
+func ResetContent(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusResetContent).AddData(data)
+}
+func PartialContent(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusPartialContent).AddData(data)
+}
+func MultiStatus(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusMultiStatus).AddData(data)
+}
+func AlreadyReported(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusAlreadyReported).AddData(data)
+}
+func IMUsed(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusIMUsed).AddData(data)
+}
+
 func BadRequest(data interface{}) *ResponseMessage {
 	return NewResponse(http.StatusBadRequest).AddData(data)
 }
@@ -40,6 +59,73 @@ func MethodNotAllowed(data interface{}) *ResponseMessage {
 
 func NotAcceptable(data interface{}) *ResponseMessage {
 	return NewResponse(http.StatusNotAcceptable).AddData(data)
+}
+
+func ProxyAuthRequired(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusProxyAuthRequired).AddData(data)
+}
+func RequestTimeout(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusRequestTimeout).AddData(data)
+}
+func Conflict(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusConflict).AddData(data)
+}
+func Gone(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusGone).AddData(data)
+}
+func LengthRequired(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusLengthRequired).AddData(data)
+}
+func PreconditionFailed(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusPreconditionFailed).AddData(data)
+}
+func RequestEntityTooLarge(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusRequestEntityTooLarge).AddData(data)
+}
+func RequestURITooLong(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusRequestURITooLong).AddData(data)
+}
+func UnsupportedMediaType(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusUnsupportedMediaType).AddData(data)
+}
+func RequestedRangeNotSatisfiable(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusRequestedRangeNotSatisfiable).AddData(data)
+}
+func ExpectationFailed(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusExpectationFailed).AddData(data)
+}
+func Teapot(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusTeapot).AddData(data)
+}
+func MisdirectedRequest(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusMisdirectedRequest).AddData(data)
+}
+func UnprocessableEntity(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusUnprocessableEntity).AddData(data)
+}
+func Locked(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusLocked).AddData(data)
+}
+func FailedDependency(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusFailedDependency).AddData(data)
+}
+func TooEarly(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusTooEarly).AddData(data)
+}
+func UpgradeRequired(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusUpgradeRequired).AddData(data)
+}
+func PreconditionRequired(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusPreconditionRequired).AddData(data)
+}
+func TooManyRequests(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusTooManyRequests).AddData(data)
+}
+func RequestHeaderFieldsTooLarge(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusRequestHeaderFieldsTooLarge).AddData(data)
+}
+func UnavailableForLegalReasons(data interface{}) *ResponseMessage {
+	return NewResponse(http.StatusUnavailableForLegalReasons).AddData(data)
 }
 
 func InternalServerError(message string) *ResponseMessage {

--- a/response_helpers_test.go
+++ b/response_helpers_test.go
@@ -24,6 +24,37 @@ func TestAccepted(t *testing.T) {
 	checkResponseSuccess(resp, http.StatusAccepted)
 }
 
+func TestNonAuthoritativeInfo(t *testing.T) {
+	RegisterTestingT(t)
+	resp := NonAuthoritativeInfo("test")
+	checkResponseSuccess(resp, http.StatusNonAuthoritativeInfo)
+}
+func TestResetContent(t *testing.T) {
+	RegisterTestingT(t)
+	resp := ResetContent("test")
+	checkResponseSuccess(resp, http.StatusResetContent)
+}
+func TestPartialContent(t *testing.T) {
+	RegisterTestingT(t)
+	resp := PartialContent("test")
+	checkResponseSuccess(resp, http.StatusPartialContent)
+}
+func TestMultiStatus(t *testing.T) {
+	RegisterTestingT(t)
+	resp := MultiStatus("test")
+	checkResponseSuccess(resp, http.StatusMultiStatus)
+}
+func TestAlreadyReported(t *testing.T) {
+	RegisterTestingT(t)
+	resp := AlreadyReported("test")
+	checkResponseSuccess(resp, http.StatusAlreadyReported)
+}
+func TestIMUsed(t *testing.T) {
+	RegisterTestingT(t)
+	resp := IMUsed("test")
+	checkResponseSuccess(resp, http.StatusIMUsed)
+}
+
 func TestNoContent(t *testing.T) {
 	RegisterTestingT(t)
 	resp := NoContent()
@@ -70,6 +101,117 @@ func TestNotAcceptable(t *testing.T) {
 	RegisterTestingT(t)
 	resp := NotAcceptable("test")
 	checkResponseFail(resp, http.StatusNotAcceptable)
+}
+
+func TestProxyAuthRequired(t *testing.T) {
+	RegisterTestingT(t)
+	resp := ProxyAuthRequired("test")
+	checkResponseFail(resp, http.StatusProxyAuthRequired)
+}
+func TestRequestTimeout(t *testing.T) {
+	RegisterTestingT(t)
+	resp := RequestTimeout("test")
+	checkResponseFail(resp, http.StatusRequestTimeout)
+}
+func TestConflict(t *testing.T) {
+	RegisterTestingT(t)
+	resp := Conflict("test")
+	checkResponseFail(resp, http.StatusConflict)
+}
+func TestGone(t *testing.T) {
+	RegisterTestingT(t)
+	resp := Gone("test")
+	checkResponseFail(resp, http.StatusGone)
+}
+func TestLengthRequired(t *testing.T) {
+	RegisterTestingT(t)
+	resp := LengthRequired("test")
+	checkResponseFail(resp, http.StatusLengthRequired)
+}
+func TestPreconditionFailed(t *testing.T) {
+	RegisterTestingT(t)
+	resp := PreconditionFailed("test")
+	checkResponseFail(resp, http.StatusPreconditionFailed)
+}
+func TestRequestEntityTooLarge(t *testing.T) {
+	RegisterTestingT(t)
+	resp := RequestEntityTooLarge("test")
+	checkResponseFail(resp, http.StatusRequestEntityTooLarge)
+}
+func TestRequestURITooLong(t *testing.T) {
+	RegisterTestingT(t)
+	resp := RequestURITooLong("test")
+	checkResponseFail(resp, http.StatusRequestURITooLong)
+}
+func TestUnsupportedMediaType(t *testing.T) {
+	RegisterTestingT(t)
+	resp := UnsupportedMediaType("test")
+	checkResponseFail(resp, http.StatusUnsupportedMediaType)
+}
+func TestRequestedRangeNotSatisfiable(t *testing.T) {
+	RegisterTestingT(t)
+	resp := RequestedRangeNotSatisfiable("test")
+	checkResponseFail(resp, http.StatusRequestedRangeNotSatisfiable)
+}
+func TestExpectationFailed(t *testing.T) {
+	RegisterTestingT(t)
+	resp := ExpectationFailed("test")
+	checkResponseFail(resp, http.StatusExpectationFailed)
+}
+func TestTeapot(t *testing.T) {
+	RegisterTestingT(t)
+	resp := Teapot("test")
+	checkResponseFail(resp, http.StatusTeapot)
+}
+func TestMisdirectedRequest(t *testing.T) {
+	RegisterTestingT(t)
+	resp := MisdirectedRequest("test")
+	checkResponseFail(resp, http.StatusMisdirectedRequest)
+}
+func TestUnprocessableEntity(t *testing.T) {
+	RegisterTestingT(t)
+	resp := UnprocessableEntity("test")
+	checkResponseFail(resp, http.StatusUnprocessableEntity)
+}
+func TestLocked(t *testing.T) {
+	RegisterTestingT(t)
+	resp := Locked("test")
+	checkResponseFail(resp, http.StatusLocked)
+}
+func TestFailedDependency(t *testing.T) {
+	RegisterTestingT(t)
+	resp := FailedDependency("test")
+	checkResponseFail(resp, http.StatusFailedDependency)
+}
+func TestTooEarly(t *testing.T) {
+	RegisterTestingT(t)
+	resp := TooEarly("test")
+	checkResponseFail(resp, http.StatusTooEarly)
+}
+func TestUpgradeRequired(t *testing.T) {
+	RegisterTestingT(t)
+	resp := UpgradeRequired("test")
+	checkResponseFail(resp, http.StatusUpgradeRequired)
+}
+func TestPreconditionRequired(t *testing.T) {
+	RegisterTestingT(t)
+	resp := PreconditionRequired("test")
+	checkResponseFail(resp, http.StatusPreconditionRequired)
+}
+func TestTooManyRequests(t *testing.T) {
+	RegisterTestingT(t)
+	resp := TooManyRequests("test")
+	checkResponseFail(resp, http.StatusTooManyRequests)
+}
+func TestRequestHeaderFieldsTooLarge(t *testing.T) {
+	RegisterTestingT(t)
+	resp := RequestHeaderFieldsTooLarge("test")
+	checkResponseFail(resp, http.StatusRequestHeaderFieldsTooLarge)
+}
+func TestUnavailableForLegalReasons(t *testing.T) {
+	RegisterTestingT(t)
+	resp := UnavailableForLegalReasons("test")
+	checkResponseFail(resp, http.StatusUnavailableForLegalReasons)
 }
 
 func TestInternalServerError(t *testing.T) {

--- a/version.go
+++ b/version.go
@@ -4,6 +4,6 @@ const ApplicationName = "httping-go"
 
 var GitCommit string
 
-const Version = "0.14.0"
+const Version = "0.14.1"
 
 var VersionPrerelease = ""


### PR DESCRIPTION
### 0.14.1

* Helpers for responses. **Status**: 
    * ProxyAuthRequired
    * RequestTimeout
    * Conflict
    * Gone
    * LengthRequired
    * PreconditionFailed
    * RequestEntityTooLarge
    * RequestURITooLong
    * UnsupportedMediaType
    * RequestedRangeNotSatisfiable
    * ExpectationFailed
    * Teapot
    * MisdirectedRequest
    * UnprocessableEntity
    * Locked
    * FailedDependency
    * TooEarly
    * UpgradeRequired
    * PreconditionRequired
    * TooManyRequests
    * RequestHeaderFieldsTooLarge
    * UnavailableForLegalReasons
    * NonAuthoritativeInfo
    * ResetContent
    * PartialContent
    * MultiStatus
    * AlreadyReported
    * IMUsed